### PR TITLE
Update culture page formatting

### DIFF
--- a/About-OWL/our-culture.md
+++ b/About-OWL/our-culture.md
@@ -2,75 +2,73 @@
 
 ## The Collaborative Culture we Model in our Work
 
-OWL’s working philosophy (that everyone can contribute, regardless of title, tenure with the organization, etc.) means that everyone on our team is empowered to bring our mission and vision to life by making a positive, value-adding impact with everything they do. Every day. We are able to effectively model this approach because our team brings a vast and diverse array of experience (in and out of education) to the table. As such, no one should feel that they don't have to have the required degree, certification, minimum service time, or specific role that makes them less of a contributor to the important work OWL does or to the tools we use. 
+OWL's working philosophy (that everyone can contribute, regardless of title, tenure with the organization, etc.) means that everyone on our team is empowered to bring our mission and vision to life by making a positive, value-adding impact with everything they do. Every day. We are able to effectively model this approach because our team brings a vast and diverse array of experience (in and out of education) to the table. As such, no one should feel that they don't have to have the required degree, certification, minimum service time, or specific role that makes them less of a contributor to the important work OWL does or to the tools we use. 
 
-This open, radically collaborative, collective leadership approach works because we're a team of passionate people who want to help each other, our nonprofit, and the educators we network with in the broader OWL community succeed. We learn from each other, challenge each other, and thank each other. The minimum that’s asked of you in such a collaborative culture is to come to the work everyday prepared to do whatever it takes to help shape the future of the organization as we strive to live our mission and vision\!
+This open, radically collaborative, collective leadership approach works because we're a team of passionate people who want to help each other, our nonprofit, and the educators we network with in the broader OWL community succeed. We learn from each other, challenge each other, and thank each other. The minimum that's asked of you in such a collaborative culture is to come to the work everyday prepared to do whatever it takes to help shape the future of the organization as we strive to live our mission and vision\!
 
-## **WORKING IN “*THE OPEN SOURCE* *WAY”* AT OWL**
+## Working "the Open Source Way" at OWL
 
-The “open” in Open Way Learning is rooted in our core philosophy of “working in the open source way” \- an ethos that shapes how we collaborate, create, and contribute, both internally and externally. While our collective leadership model empowers everyone to make mission-aligned decisions, our open source mindset shapes how we share knowledge, build tools, and iterate together in public view.
+The "open" in Open Way Learning is rooted in our core philosophy of "working the open source way"—an ethos that shapes how we collaborate, create, and contribute, both internally and externally. While our collective leadership model empowers everyone to make mission-aligned decisions, our open source mindset shapes how we share knowledge, build tools, and iterate together in public view.
 
 This mindset stems from open source principles of transparency, collaboration, meritocracy, iteration, and community and explicitly shows up in how we:
 
-* Contribute early and often, sharing MVPs (minimum viable products) before they’re perfect.  
+* Contribute early and often, sharing MVPs (minimum viable products) before they're perfect.  
 * Prioritize working in the open (shared docs, recorded knowledge, version control).  
 * Share drafts for community input, rather than waiting for top-down approval.  
 * Invite contributions from anyone—not just those with tenure or titles.  
-* Focus on outcomes and impact, not hours clocked or formal hierarchy\*.  
-  *\* A note on “Focusing on Outcomes and Impact” \- While we value results and trust team members to manage their time independently, this principle should not be confused with a culture of overwork, perfectionism, or dismissing the value of effort. We recognize that meaningful progress often comes from process, relationship-building, and iteration, even when the final product is still emerging. This value simply reinforces our belief that impactful contributions matter more than visible busyness. It aligns with our flexible PTO policy and anti-burnout culture. We encourage everyone to take time off, recharge, and ask for support, because sustainable impact depends on sustainable people.*
+* Focus on outcomes and impact, not hours clocked or formal hierarchy.[^outcomes-and-impact]
 
 Working this way means:
 
-* You’re empowered to try something new, fail forward\*, and improve quickly.  
+* You're empowered to try something new, fail forward,[^fail-forward] and improve quickly.  
 * You should always default to openness in communication, file sharing, and knowledge creation.  
 * You are encouraged to use and contribute back to open-source tools and projects where applicable.  
 * You help us model this mindset for schools, communities, and partners we serve.
 
-Pro Tip: An MVP must still meet high quality expectations that reflect OWL’s high professional standards before going “live” to an external partner or client. If you’re unsure whether something is “ready enough,” ask an OWL colleague for input.
-
-\**Note on “Failing Forward”: We believe that failure \- when it’s safe, intentional, and reflective \- is a powerful tool for learning and innovation. As described in [this video](https://www.youtube.com/watch?v=Gb9tjnJWu5g), not all failure is created equal. OWL encourages “intelligent failures”that result from well-reasoned, mission-aligned risks and iterative experimentation, not from negligence, avoidable mistakes, or patterns of underperformance (especially if it has potential to affect OWL’s reputation). If you're unsure whether a decision or action falls within that distinction, seek peer feedback or check in with a teammate or Director.*
+{% hint style="success" %}
+An MVP must still meet high quality expectations that reflect OWL's high professional standards before going "live" to an external partner or client. If you're unsure whether something is "ready enough," ask an OWL colleague for input.
+{% endhint %}
 
 Finally, our open-source ethos informs how we hire, organize, and grow:
 
 * We value asynchronous work, flexible schedules, and distributed collaboration.  
 * We hire from our networks and communities—prioritizing alignment and contribution over credentials.  
-* We design compensation and performance expectations that reflect our primary customer base \- educators.  
-* Writing down and recording knowledge (over verbal explanations).  
-  *\*A note on why we document: As stated at the beginning of this Handbook, at OWL we honor multiple ways of knowing and sharing information, including verbal storytelling, visual media, and lived experience. That said, we intentionally default to written and openly accessible documentation as a core part of our open-source culture. This approach, inspired by organizations like [GitLab](https://about.gitlab.com/blog/our-handbook-is-open-source-heres-why/) and Red Hat, is not just about policies—it’s about transparency, collective memory, and equitable access. Writing things down (or recording them in searchable, shareable formats) ensures that knowledge isn’t gatekept by proximity, tenure, or personality. As such, this open Handbook is the living source code of OWL \- a way to include all voices, adapt with feedback, and ensure everyone can understand not just what we do, but why and how we do it. It’s how we stay aligned, inclusive, and agile as we grow.*
+* We design compensation and performance expectations that reflect our primary customer base: educators.  
+* Writing down and recording knowledge (over verbal explanations).[^recording-knowledge]
 
-In essence, OWL is not just an open organization—we are an open-source movement in education. We don’t just use these values \- we live them.
+In essence, OWL is not just an open organization—we are an open-source movement in education. We don't just "use" these values; we live them.
 
-## **OWL COLLECTIVE LEADERSHIP**
+## OWL Collective Leadership
 
-At Open Way Learning, leadership is not tied to titles, it’s embedded in how we work, share decisions, and advance our mission together. Inspired by open-source principles of transparency, adaptability, inclusivity, and shared responsibility, OWL operates using a collective leadership model that empowers all team members to lead in their roles, contribute to strategic decisions, and take ownership of execution.
+At Open Way Learning, leadership is not tied to titles; it's embedded in how we work, share decisions, and advance our mission together. Inspired by open source principles of transparency, adaptability, inclusivity, and shared responsibility, OWL operates using a collective leadership model that empowers all team members to lead in their roles, contribute to strategic decisions, and take ownership of execution.
 
 This approach is both a culture and a structure, designed to ensure that our work remains mission-aligned, human-centered, and responsive in a rapidly changing education landscape.
 
-Unlike conventional hierarchies or top-down management, OWL’s collective leadership model is rooted in the belief that distributed, informed decision-making leads to better, faster, and more sustainable outcomes. Here's how it differs:
+Unlike conventional hierarchies or top-down management, OWL's collective leadership model is rooted in the belief that distributed, informed decision-making leads to better, faster, and more sustainable outcomes. Here's how it differs:
 
-* Decentralized Authority with Shared Accountability: Leadership is distributed across the team, but grounded in clarity of roles and responsibilities. Everyone is empowered to lead where they are, within the boundaries of our mission, strategic goals, and the RACI framework (see below).  
-* Open Access to Information: Instead of relying on gatekeepers, we invest in systems (like our Employee Handbook, SOPs, shared drives, and Productive) to ensure retrieval of knowledge is fast and accessible to all—allowing anyone to step in with clarity and confidence.  
-* Bias for Action & Learning: We prioritize many informed decisions over perfect consensus, embracing iteration, reflection, and rapid feedback as a means of learning and improving together.
+* **Decentralized Authority with Shared Accountability:** Leadership is distributed across the team, but grounded in clarity of roles and responsibilities. Everyone is empowered to lead where they are, within the boundaries of our mission, strategic goals, and the RACI framework (see below).  
+* **Open Access to Information:** Instead of relying on gatekeepers, we invest in systems (like our Employee Handbook, SOPs, shared drives, and Productive) to ensure retrieval of knowledge is fast and accessible to all—allowing anyone to step in with clarity and confidence.  
+* **Bias for Action & Learning:** We prioritize many informed decisions over perfect consensus, embracing iteration, reflection, and rapid feedback as a means of learning and improving together.
 
-### **Key Pillars of Collective Leadership at OWL:**
+### Key Pillars of Collective Leadership at OWL
 
-* Mission-Driven Decision Making \- Every decision starts with one question: Does this align with our mission, vision, values, and current strategic goals? If not, the decision must be escalated to the Director team or, if major, to the Board.  
-* Radical Trust \- Trust is the currency of our culture. We assume positive intent, encourage open dialogue, and support each other in making good-faith decisions, even when the path is ambiguous. “Open” in OWL means transparent, respectful, and accountable.  
-* Clarity \= Agility \- Role clarity (not control) enables quick and informed decisions. We rely on a living RACI Matrix to define who is Responsible, Accountable, Consulted, Informed, and who plays a Support role across decisions. When ambiguity arises, we talk it through \- not around it.  
-* Execution and Iteration \- Decisions must be followed by action—and action must be followed by reflection. Every decision sets a new baseline for learning. We operate in continuous beta, not perfection mode.  
-* Feedback as a Leadership Act \- We normalize regular feedback (both formal and informal) as a form of care, alignment, and mutual respect. Constructive input and reflection are key leadership tools for everyone at OWL.  
-* Shared Tools and Protocols \- We use a shared Decision-Making Protocol for complex or multi-stakeholder decisions. This includes:  
-  * Define the problem  
-  * Gather input  
-  * Co-generate solutions  
-  * Evaluate tradeoffs  
-  * Decide  
-  * Communicate clearly  
-  * Reflect and improve
+* **Mission-Driven Decision Making:** Every decision starts with one question: Does this align with our mission, vision, values, and current strategic goals? If not, the decision must be escalated to the Director team or, if major, to the Board.  
+* **Radical Trust:** Trust is the currency of our culture. We assume positive intent, encourage open dialogue, and support each other in making good-faith decisions, even when the path is ambiguous. "Open" in OWL means transparent, respectful, and accountable.  
+* **Clarity = Agility:** Role clarity (not control) enables quick and informed decisions. We rely on a living RACI Matrix to define who is Responsible, Accountable, Consulted, Informed, and who plays a Support role across decisions. When ambiguity arises, we talk it through—not around it.  
+* **Execution and Iteration:** Decisions must be followed by action—and action must be followed by reflection. Every decision sets a new baseline for learning. We operate in continuous beta, not perfection mode.  
+* **Feedback as a Leadership Act:** We normalize regular feedback (both formal and informal) as a form of care, alignment, and mutual respect. Constructive input and reflection are key leadership tools for everyone at OWL.  
+* **Shared Tools and Protocols:** We use a shared Decision-Making Protocol for complex or multi-stakeholder decisions. This includes:
+	* Define the problem  
+	* Gather input  
+	* Co-generate solutions  
+	* Evaluate tradeoffs  
+	* Decide  
+	* Communicate clearly  
+	* Reflect and improve
 
 We also maintain a centralized Decision Log, regularly updated by our Manager of Operations to track key strategic and financial decisions.
 
-### **How This Shows Up in Our Work:**
+### How This Shows Up in Our Work
 
 * All Directors share responsibility for internal systems, program quality, partner relationships, and org-wide strategy. We meet weekly to raise, track, and resolve decisions collaboratively.  
 * Staff and Fellows contribute to decision-making in their scope and are encouraged to suggest changes or identify gaps.  
@@ -79,37 +77,37 @@ We also maintain a centralized Decision Log, regularly updated by our Manager of
 
 This model empowers everyone at OWL to contribute meaningfully to the mission—not just through ideas, but through decisions and execution. It accelerates progress, builds internal leadership capacity, and ensures our clients and communities benefit from a nimble, human-centered organization that models the kind of leadership we hope to see in schools.
 
-For more on the tools, processes, and responsibilities tied to OWL’s collective leadership model, refer to the [Collective Leadership SOP](https://docs.google.com/document/d/19iW5Q-XKk6P9aYqBYttqXBbXAY9IQz_kgZdPv_AfFQI/edit?usp=sharing).
+For more on the tools, processes, and responsibilities tied to OWL's collective leadership model, refer to the [Collective Leadership SOP](https://docs.google.com/document/d/19iW5Q-XKk6P9aYqBYttqXBbXAY9IQz_kgZdPv_AfFQI/edit?usp=sharing).
 
-## **SUSTAINING AN AGILE, STARTUP MINDSET AS WE GROW**
+## Sustaining an Agile, Startup Mindset as we Grow
 
-As OWL expands our reach and impact, we are committed to staying agile, open, and focused—not slow, bureaucratic, or overly hierarchical. We draw inspiration from models like Kotter’s Dual Operating System, which remind us that an organization can run like a scaling company and a nimble startup at the same time—if it intentionally supports both. This balance helps us:
+As OWL expands our reach and impact, we are committed to staying agile, open, and focused—not slow, bureaucratic, or overly hierarchical. We draw inspiration from models like Kotter's Dual Operating System, which remind us that an organization can run like a scaling company and a nimble startup at the same time—if it intentionally supports both. This balance helps us:
 
 * Move quickly on opportunities;  
 * Iterate with confidence;  
 * Maintain quality and consistency as we grow;  
 * Stay grounded in purpose, not process.
 
-We call this our startup mindset, and it’s a conscious choice \- not something that just “happens.” It’s what lets us remain true to our mission while adapting to a changing education landscape.
+We call this our startup mindset, and it's a conscious choice—not something that just "happens." It's what lets us remain true to our mission while adapting to a changing education landscape.
 
-### **What This Looks Like at OWL**
+### What This Looks Like at OWL
 
-Maintaining this mindset means everyone on the team is empowered to contribute \- not just to their individual work, but to how OWL works as an organization. Here’s how we practice this ethos:
+Maintaining this mindset means everyone on the team is empowered to contribute—not just to their individual work, but to how OWL works as an organization. Here's how we practice this ethos:
 
 * Actively recruit team members who thrive in open, non-hierarchical environments built on trust, transparency, and collective leadership.  
-* Use lightweight, flexible tools and workflows such as Agile check-ins, Kanban boards, “scrum-style” collaborations, and project-based swarms to move fast and adapt quickly.  
+* Use lightweight, flexible tools and workflows such as Agile check-ins, Kanban boards, "scrum-style" collaborations, and project-based swarms to move fast and adapt quickly.  
 * Hire for purpose and potential, and support autonomy through meaningful compensation, flexible schedules, and a clear connection to impact.  
-* Say no to the wrong work \- even if the price tag is tempting \- when it doesn’t align with our mission or values.  
+* Say no to the wrong work—even if the price tag is tempting—when it doesn't align with our mission or values.  
 * Default to transparency, sharing information openly inside and outside the org whenever possible.  
-* Empower people to understand the “why” behind decisions and tasks. If it’s not clear, ask. If it could be improved, speak up.  
-* Treat this Handbook as a living document \- a reference, not a rulebook. Use it to move faster, not to ask for permission.  
+* Empower people to understand the "why" behind decisions and tasks. If it's not clear, ask. If it could be improved, speak up.  
+* Treat this Handbook as a living document—a reference, not a rulebook. Use it to move faster, not to ask for permission.  
 * *Go slow to go fast* by investing in clarity, culture, and alignment early so that our work scales meaningfully and sustainably.
 
 In short, we believe that staying lean and curious makes us more creative, more collaborative, and more impactful. And we know that the best ideas often come from the edges, not the center. As we scale, we grow stronger and smarter, not more rigid.
 
-**Agile tools we use (and why they matter)**
+### Agile Tools we Use (and Why They Matter)
 
-We adopt lean, startup-inspired practices not because it’s trendy, but because it helps us stay true to our culture and mission. This includes:
+We adopt lean, startup-inspired practices not because it's trendy, but because it helps us stay true to our culture and mission. This includes:
 
 * Staying aligned without unnecessary meetings  
 * Making our work visible (and finish what we start)  
@@ -118,47 +116,49 @@ We adopt lean, startup-inspired practices not because it’s trendy, but because
 * Protecting quality and avoiding burnout  
 * Meeting commitments, including starting and ending on time
 
-Here’s how we live that out:
+Here's how we live that out:
 
 | Tool/Practice | What It Is | Why OWL Uses It |
-| ----- | ----- | ----- |
-| **Weekly Scrums** | Fast, structured team check-ins (45 \- 60 min) | Ensure clarity on top priorities, blockers, and cross-team needs |
+| ------------- | ---------- | --------------- |
+| **Weekly Scrums** | Fast, structured team check-ins (45—60 min) | Ensure clarity on top priorities, blockers, and cross-team needs |
 | **Kanban Boards** | Visual boards that track work by stage | Help everyone see progress, reduce bottlenecks, stay accountable |
-| **Swarms** | Temporary “micro-teams” for urgent tasks | Activate the right people at the right time \- fast and focused |
+| **Swarms** | Temporary "micro-teams" for urgent tasks | Activate the right people at the right time—fast and focused |
 | **Timeboxing** | Setting limits for tasks or decisions | Prevent perfectionism (embracing the idea of non-closure); focus on meaningful progress |
 | **Minimum Viable Products (MVPs)** | Start small, improve over time | Test early, learn fast, refine with feedback |
-| **“Go Slow to Go Fast”** | Invest early in alignment, clarity, and relationships | We build trust, surface hidden assumptions, and reduce rework by slowing down at the start—so we can move faster, smarter, and more sustainably later on |
+| **"Go Slow to Go Fast"** | Invest early in alignment, clarity, and relationships | We build trust, surface hidden assumptions, and reduce rework by slowing down at the start—so we can move faster, smarter, and more sustainably later on |
 | **Postmortems & Retros** | Structured reflection and debrief after key events | Normalize learning from failure and celebrate wins |
 | **Async-first communication** | Slack \+ Productive \+ shared docs | Respect time zones and focus, reduce meeting overload |
 
-## **OWL’s CULTURAL COMMITMENT TO EQUITY**
+## OWL's Cultural Commitment to Equity
 
-Open Way Learning believes that meaningful innovation in education must be rooted in fairness, belonging, and opportunity for every learner. We know that schools across the country serve students from widely varied backgrounds \- racially, economically, culturally, and geographically. Our work is grounded in the belief that each of these students deserves access to innovative learning experiences that recognize their potential, reflect their identity, and prepare them for a rapidly changing world.
+Open Way Learning believes that meaningful innovation in education must be rooted in fairness, belonging, and opportunity for every learner. We know that schools across the country serve students from widely varied backgrounds—racially, economically, culturally, and geographically. Our work is grounded in the belief that each of these students deserves access to innovative learning experiences that recognize their potential, reflect their identity, and prepare them for a rapidly changing world.
 
 We also recognize that too often, students from historically underserved communities, whether because of income, race, geography, or other barriers, have been excluded from those opportunities. We are committed to helping schools change that story.
 
-Rather than applying one-size-fits-all solutions, we work alongside educators and communities to co-create learning environments that are inclusive, culturally responsive, and learner-centered. We support schools in building local solutions that expand access, elevate student voice, and ensure innovation reaches every corner of the learning community \- not just the most privileged.
+Rather than applying one-size-fits-all solutions, we work alongside educators and communities to co-create learning environments that are inclusive, culturally responsive, and learner-centered. We support schools in building local solutions that expand access, elevate student voice, and ensure innovation reaches every corner of the learning community—not just the most privileged.
 
-We also believe that the most sustainable change happens when it’s led by communities themselves. That’s why we prioritize deep, empathetic listening, shared leadership, and community-based design as we help co-design better systems \- not just for some students, but for every student.
+We also believe that the most sustainable change happens when it's led by communities themselves. That's why we prioritize deep, empathetic listening, shared leadership, and community-based design as we help co-design better systems—not just for some students, but for every student.
 
-This is important work that belongs to all of us. Every member of the OWL team is expected to contribute to this vision of equity \- not as a political stance, but as a human one. When all students are seen, heard, and supported, everyone rises.
+This is important work that belongs to all of us. Every member of the OWL team is expected to contribute to this vision of equity—not as a political stance, but as a human one. When all students are seen, heard, and supported, everyone rises.
 
 Note that OWL intentionally avoids politically charged or polarizing language in public-facing equity commitments. This is not to diminish the seriousness of systemic inequities, but to protect the work we do to ensure our mission reaches all communities. Our values remain clear: equity, inclusion, and student-centered transformation is for every student, especially those historically furthest from opportunity.
 
-## **ONE LAST THING: BRINGING THE OWL CULTURE TO LIFE (EVERY DAY)**
+## One Last Thing: Bringing the OWL Culture to Life (Every Day)
 
-No matter your role, title, or location, you’re part of a team that’s committed to something more than just getting things done \- we’re building a culture. One that models what schools themselves should feel like: curious, courageous, joyful, and generous.
+No matter your role, title, or location, you're part of a team that's committed to something more than just getting things done—we're building a culture. One that models what schools themselves should feel like: curious, courageous, joyful, and generous.
 
-So here’s our invitation to you: *Let’s not just talk about our values, let’s live them. Let’s bring energy, care, and imagination to the work we do and to the people we do it with.*
+So here's our invitation to you:
+
+> Let's not just talk about our values, let's live them. Let's bring energy, care, and imagination to the work we do and to the people we do it with.
 
 If you work for Open Way Learning in any capacity, here are some small ways you can help make our culture extraordinary:
 
 * Add positive energy to every conversation  
-* Practice “Yes, and…” to build on each other’s ideas  
+* Practice "Yes, and…" to build on each other's ideas  
 * Ask more questions than you give answers  
 * Remove old tasks that no longer serve our mission  
 * Treat clients better than they expect  
-* Offer help before you’re asked  
+* Offer help before you're asked  
 * Leave things more organized than you found them  
 * Invent a moment of silliness every day  
 * Highlight good work from your peers  
@@ -168,9 +168,13 @@ If you work for Open Way Learning in any capacity, here are some small ways you 
 * Spark new services that people truly want  
 * Read, explore, and feed your curiosity  
 * Celebrate tough decisions and the clarity they bring  
-* Learn from what didn’t work—and talk about it  
+* Learn from what didn't work—and talk about it  
 * And yes… smile a lot
 
-These aren’t rules. They’re reminders of what kind of place we want this to be, and what kind of teammates we want to be for each other.
+These aren't rules. They're reminders of what kind of place we want this to be, and what kind of teammates we want to be for each other.
 
-Want to go deeper? Check out [The Culture Code](https://danielcoyle.com/the-culture-code/) by Daniel Coyle for insight into why psychological safety, shared vulnerability, and purpose are the cornerstones of any high-performing culture. Or revisit [Let My People Go Surfing](https://www.patagonia.com/product/let-my-people-go-surfing-revised-paperback-book/BK067.html) by Yvon Chouinard for a model of purpose-driven work grounded in flexibility and trust.  
+Want to go deeper? Check out [The Culture Code](https://danielcoyle.com/the-culture-code/) by Daniel Coyle for insight into why psychological safety, shared vulnerability, and purpose are the cornerstones of any high-performing culture. Or revisit [Let My People Go Surfing](https://www.patagonia.com/product/let-my-people-go-surfing-revised-paperback-book/BK067.html) by Yvon Chouinard for a model of purpose-driven work grounded in flexibility and trust.
+
+[^outcomes-and-impact]: While we value results and trust team members to manage their time independently, this principle should not be confused with a culture of overwork, perfectionism, or dismissing the value of effort. We recognize that meaningful progress often comes from process, relationship-building, and iteration, even when the final product is still emerging. This value simply reinforces our belief that impactful contributions matter more than visible busyness. It aligns with our flexible PTO policy and anti-burnout culture. We encourage everyone to take time off, recharge, and ask for support, because sustainable impact depends on sustainable people.
+[^fail-forward]: We believe that failure—when it's safe, intentional, and reflective—is a powerful tool for learning and innovation. As described in [this video](https://www.youtube.com/watch?v=Gb9tjnJWu5g), not all failure is created equal. OWL encourages "intelligent failures" that result from well-reasoned, mission-aligned risks and iterative experimentation, not from negligence, avoidable mistakes, or patterns of underperformance (especially if it has potential to affect OWL's reputation). If you're unsure whether a decision or action falls within that distinction, seek peer feedback or check in with a teammate or Director.
+[^recording-knowledge]: As stated at the beginning of this Handbook, at OWL we honor multiple ways of knowing and sharing information, including verbal storytelling, visual media, and lived experience. That said, we intentionally default to written and openly accessible documentation as a core part of our open-source culture. This approach, inspired by organizations like [GitLab](https://about.gitlab.com/blog/our-handbook-is-open-source-heres-why/) and Red Hat, is not just about policies—it's about transparency, collective memory, and equitable access. Writing things down (or recording them in searchable, shareable formats) ensures that knowledge isn't gatekept by proximity, tenure, or personality. As such, this open Handbook is the living source code of OWL—a way to include all voices, adapt with feedback, and ensure everyone can understand not just what we do, but why and how we do it. It's how we stay aligned, inclusive, and agile as we grow.


### PR DESCRIPTION
This pull request suggests stylistic and formatting-related updates to the `Our Culture` page of the OWL handbook. Primarily, it:

- Standardizes headings and sub-headings as consistent with the rest of the handbook
- Removes superfluous formatting
- Add notes and pull-outs for emphasis
- Relocates inline notes to page endnotes